### PR TITLE
Bump react dep, move mockExecuteAction to avoid context warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fluxible-action-utils",
   "description": "utility methods to aid in writing actions for fluxible based applications.",
-  "version": "0.3.0",
+  "version": "0.2.1",
   "main": "index.js",
   "repository": {
     "type": "git",
@@ -15,8 +15,7 @@
     "test": "npm run lint && npm run cover"
   },
   "dependencies": {
-    "async": "^0.9.0",
-    "react": "^0.13.0"
+    "async": "^0.9.0"
   },
   "devDependencies": {
     "chai": "^2.0",
@@ -27,8 +26,12 @@
     "mocha": "^2.0",
     "mockery": "^1.0",
     "precommit-hook": "^1.0",
+    "react": ">=0.12.0 <=0.13.x",
     "sinon": "^1.0",
     "webpack": "^1.0"
+  },
+  "peerDependencies": {
+    "react": ">=0.12.0 <=0.13.x"
   },
   "author": "Mo Kouli <mkouli@yahoo-inc.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fluxible-action-utils",
   "description": "utility methods to aid in writing actions for fluxible based applications.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "index.js",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "async": "^0.9.0",
-    "react": "^0.12.0"
+    "react": "^0.13.0"
   },
   "devDependencies": {
     "chai": "^2.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test": "npm run lint && npm run cover"
   },
   "dependencies": {
-    "async": "^0.9.0"
+    "async": "^0.9.0",
+    "react": ">=0.12.0 <=0.13.x"
   },
   "devDependencies": {
     "chai": "^2.0",
@@ -26,7 +27,6 @@
     "mocha": "^2.0",
     "mockery": "^1.0",
     "precommit-hook": "^1.0",
-    "react": ">=0.12.0 <=0.13.x",
     "sinon": "^1.0",
     "webpack": "^1.0"
   },

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "test": "npm run lint && npm run cover"
   },
   "dependencies": {
-    "async": "^0.9.0",
-    "react": ">=0.12.0 <=0.13.x"
+    "async": "^0.9.0"
   },
   "devDependencies": {
     "chai": "^2.0",
@@ -27,6 +26,7 @@
     "mocha": "^2.0",
     "mockery": "^1.0",
     "precommit-hook": "^1.0",
+    "react": ">=0.12.0 <=0.13.x",
     "sinon": "^1.0",
     "webpack": "^1.0"
   },

--- a/tests/unit/mixins.js
+++ b/tests/unit/mixins.js
@@ -12,6 +12,10 @@ GLOBAL.document = jsdom.jsdom('<!doctype html><html><body></body></html>');
 GLOBAL.window = GLOBAL.document.parentWindow;
 GLOBAL.navigator = GLOBAL.window.navigator;
 
+function mockExecuteAction (action, params) {
+    action(params);
+}
+
 function renderComponent (classSpec, container) {
     var _classSpec = {
         mixins: [PeriodicActionsMixin],
@@ -32,9 +36,7 @@ function renderComponent (classSpec, container) {
                 },
                 getChildContext: function () {
                     return {
-                        executeAction: function (action, params) {
-                            action(params);
-                        }
+                        executeAction: mockExecuteAction
                     };
                 },
                 render: function () {


### PR DESCRIPTION
@koulmomo 
Support React@0.13 or React@0.12

Had to update my test helper so that we wouldn't get [erroneous warnings](https://fb.me/react-context-by-parent) about context owner vs parent (stems from the fact that [React calls `getChildContext` twice](https://github.com/rackt/react-router/issues/638#issuecomment-74289882) and looks for mismatches and since my function was nested it would create two different functions)