### PR TITLE
Update: dev deps (eslint, pre-commit)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
   "devDependencies": {
     "chai": "^2.0",
     "coveralls": "^2.11.1",
-    "eslint": "^0.16.0",
+    "eslint": "^0.17.0",
     "istanbul": "^0.3.5",
     "jsdom": "^3.0",
     "mocha": "^2.0",
     "mockery": "^1.0",
-    "precommit-hook": "^1.0",
+    "precommit-hook": "^2.0",
     "react": ">=0.12.0 <=0.13.x",
     "sinon": "^1.0",
     "webpack": "^1.0"
@@ -57,7 +57,7 @@
     "async",
     "react"
   ],
-  "precommit": [
+  "pre-commit": [
     "lint",
     "devtest"
   ]

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "jsdom": "^3.0",
     "mocha": "^2.0",
     "mockery": "^1.0",
-    "precommit-hook": "^2.0",
+    "pre-commit": "^1.0",
     "react": ">=0.12.0 <=0.13.x",
     "sinon": "^1.0",
     "webpack": "^1.0"


### PR DESCRIPTION
@koulmomo 
Upgrading the two devDeps that we can update.
Sadly, we can't update `jsdom` because they don't support our *legacy* platform, nodejs