### PR TITLE
Removing React peer dep, using custom validator

### DIFF
--- a/mixins/PeriodicActions.js
+++ b/mixins/PeriodicActions.js
@@ -6,7 +6,6 @@
 
 'use strict';
 
-var React = require('react');
 var intervalsMap = {};
 var uuidMap = {};
 
@@ -36,7 +35,11 @@ function getIntervalRunner (context, actions) {
 
 module.exports = {
     contextTypes: {
-        executeAction: React.PropTypes.func
+        executeAction: function (props, propName) {
+            if (typeof props[propName] !== 'function') {
+                return new Error('Validation failed, function expected!');
+            }
+        }
     },
     /**
      * Start running an action periodically

--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
     "sinon": "^1.0",
     "webpack": "^1.0"
   },
-  "peerDependencies": {
-    "react": ">=0.12.0 <=0.13.x"
-  },
   "author": "Mo Kouli <mkouli@yahoo-inc.com>",
   "contributors": [
     {

--- a/tests/unit/mixins.js
+++ b/tests/unit/mixins.js
@@ -64,6 +64,35 @@ function unmount (container) {
 }
 
 describe('PeriodicActions', function () {
+    it('has a custom validator for context.executeAction', function () {
+        var contextTypes = PeriodicActionsMixin.contextTypes;
+        var executeActionValidator = null;
+
+        expect(contextTypes).to.be.an('object');
+
+        executeActionValidator = contextTypes.executeAction;
+        expect(executeActionValidator).to.be.a('function');
+
+        // Test inputs
+        [
+            false,
+            true,
+            null,
+            undefined,
+            0,
+            10,
+            '',
+            'nope',
+            /test/,
+            {},
+            []
+        ].forEach(function (value) {
+            expect(executeActionValidator({executeAction: value}, 'executeAction')).to.be.an.instanceof(Error);
+        });
+
+        expect(executeActionValidator({executeAction: function () {}}, 'executeAction')).to.be.an('undefined');
+    });
+
     it('will fire periodic actions and stop', function () {
         // We'll need to be able to speed up time
         var clock = sinon.useFakeTimers();

--- a/tests/unit/mixins.js
+++ b/tests/unit/mixins.js
@@ -90,7 +90,7 @@ describe('PeriodicActions', function () {
             expect(executeActionValidator({executeAction: value}, 'executeAction')).to.be.an.instanceof(Error);
         });
 
-        expect(executeActionValidator({executeAction: function () {}}, 'executeAction')).to.be.an('undefined');
+        expect(executeActionValidator({executeAction: function () {}}, 'executeAction')).to.be.undefined;
     });
 
     it('will fire periodic actions and stop', function () {


### PR DESCRIPTION
@koulmomo @akshayp 
It always felt like overkill to require all of React just for one PropType check.
I recently found that the React docs do cover using custom validators, last example in the code block: http://facebook.github.io/react/docs/reusable-components.html#prop-validation

Hopefully this will make transitions to newer React versions smoother... assuming they don't get rid of mixins anytime soon.